### PR TITLE
infra setup for graviton vs x86 test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+

--- a/infra/backend.tf
+++ b/infra/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "local" {
+    path          = "infra-terraform.tfstate"
+  }
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,66 @@
+# Configure the AWS Provider
+provider "aws" {
+  region = "us-east-1"
+}
+
+# vpc
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.7.0"
+
+  name = "graviton2-hackathon-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs             = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+
+  enable_nat_gateway = true
+  single_nat_gateway = true
+  one_nat_gateway_per_az = false
+
+  tags = {
+    Terraform = "true"
+    Environment = "dev"
+  }
+}
+
+
+# eks 
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "17.20.0"
+
+  cluster_version = "1.21"
+  cluster_name    = "graviton2-hackathon"
+  vpc_id          = module.vpc.vpc_id
+  subnets         = module.vpc.private_subnets
+
+  node_groups = {
+    default = {
+      desired_capacity = 1
+      max_capacity     = 1
+      min_capacity     = 1
+
+      instance_types = ["t4g.small"]
+      capacity_type  = "SPOT"
+      k8s_labels = {
+        Environment = "test"
+      }
+    }  
+  }
+}
+
+data "aws_eks_cluster" "eks" {
+  name = module.eks.cluster_id
+}
+
+data "aws_eks_cluster_auth" "eks" {
+  name = module.eks.cluster_id
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.eks.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.eks.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.eks.token
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -3,29 +3,6 @@ provider "aws" {
   region = "us-east-1"
 }
 
-# vpc
-module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "3.7.0"
-
-  name = "graviton2-hackathon-vpc"
-  cidr = "10.0.0.0/16"
-
-  azs             = ["us-east-1a", "us-east-1b", "us-east-1c"]
-  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
-
-  enable_nat_gateway = true
-  single_nat_gateway = true
-  one_nat_gateway_per_az = false
-
-  tags = {
-    Terraform = "true"
-    Environment = "dev"
-  }
-}
-
-
 # eks 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -37,7 +37,9 @@ module "eks" {
   subnets         = module.vpc.private_subnets
 
   node_groups = {
-    default = {
+    arm = {
+      ami_type  = "AL2_ARM_64"
+
       desired_capacity = 1
       max_capacity     = 1
       min_capacity     = 1
@@ -46,8 +48,23 @@ module "eks" {
       capacity_type  = "SPOT"
       k8s_labels = {
         Environment = "test"
+
       }
-    }  
+    }
+    x86 = {
+      ami_type  = "AL2_x86_64"
+
+      desired_capacity = 1
+      max_capacity     = 1
+      min_capacity     = 1
+
+      instance_types = ["t3.small"]
+      capacity_type  = "SPOT"
+      k8s_labels = {
+        Environment = "test"
+        
+      }
+    }    
   }
 }
 

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -1,0 +1,21 @@
+# vpc
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.7.0"
+
+  name = "graviton2-hackathon-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs             = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+
+  enable_nat_gateway = true
+  single_nat_gateway = true
+  one_nat_gateway_per_az = false
+
+  tags = {
+    Terraform = "true"
+    Environment = "dev"
+  }
+}


### PR DESCRIPTION
Infrastructure setup for graviton vs x86 testbed, including a vpc, eks cluster and two managed node groups with the differing architecture types.